### PR TITLE
Update Asset Register

### DIFF
--- a/resources/views/equipment/assets/view.blade.php
+++ b/resources/views/equipment/assets/view.blade.php
@@ -10,5 +10,5 @@
     <iframe width="100%"
             height="700"
             frameborder="0"
-            src="https://docs.google.com/spreadsheets/d/19oMod3uCJp51h_BfpCy0sprKueOWOxBXSmI1PcIm19I/pubhtml?widget=false&headers=false&chrome=false&gid=0"></iframe>
+            src="https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRBIJLyKO--ffboCd90BXWBD95DZm99cXXqi9eSnzPkoCMeMIilnRC81udAtD3ghbF4zt5bzeqDLGQb/pubhtml?widget=true&amp;headers=false"></iframe>
 @endsection


### PR DESCRIPTION
Update the "Asset Register" section of the website (https://www.bts-crew.com/equipment/assets) to point to a new published Google Docs spreadsheet containing the latest asset register.

The website-main/resources/views/equipment/assets/view.blade.php file has been updated, with the <iframe> URL pointed to the updated Asset Register spreadsheet.
