### PR TITLE
Update telephone number

### DIFF
--- a/resources/views/app/includes/footer.blade.php
+++ b/resources/views/app/includes/footer.blade.php
@@ -8,7 +8,7 @@
 
             <div>
                 <span class="fa fa-phone"></span>
-                +44 (0) 1225 383067
+                (01225) 666076
             </div>
             <div>
                 <span class="fa fa-home"></span>

--- a/resources/views/contact/enquiries.blade.php
+++ b/resources/views/contact/enquiries.blade.php
@@ -6,7 +6,7 @@
 
 @section('tab')
     <p>If you have a general question for Backstage then you can use the form below to send us an email; alternatively you are welcome to pop over to our office
-        (<em class="bts">1E 3.4</em>) or call us on <em class="bts">01225 383067</em>.</p>
+        (<em class="bts">1E 3.4</em>) or call us on <em class="bts">(01225) 666076</em>.</p>
     <p>Please do not use this to submit a booking request; use the {!! link_to_route('contact.book', 'booking request form') !!} instead.</p>
     {!! Form::open() !!}
         <!-- Text field for 'name' -->


### PR DESCRIPTION
The Uni is now charging £150/yr for an incoming-only telephone number. Their Analogue Service Units have also been decommissioned, meaning that it's no-longer possible to plug in a normal handset to receive calls in the Office. It's also not possible to connect a VoIP handset, because all Uni telephony now runs through Teams.

In light of these factors, the decision was made to rent a VoIP number from Net-Telco - a 3rd-party provider which offers Bath telephone numbers for only £10/yr, with only inbound calls allowed. Not only does this give us a significantly cheaper and justifiable phone number cost, but Net-Telco uses entirely standard SIP communication, meaning that BTS can run an Asterisk Server to interface between as many VoIP handsets as we need in our on-campus spaces, and Net-Telco's systems.

Unfortunately, it has not been possible to transfer our existing Uni-provided number over to Net-Telco, because the Uni's policies prevent "porting away" numbers from their allocated range. A new number has therefore been chosen, and the website footer updated accordingly.