### PR TITLE
feat(elections): allow admins to always nominate and set results

### DIFF
--- a/app/Http/Controllers/Elections/ElectionController.php
+++ b/app/Http/Controllers/Elections/ElectionController.php
@@ -38,6 +38,7 @@ class ElectionController extends Controller
      */
     public function view($id)
     {
+        /* @var Election $election */
         $election = Election::findOrFail($id);
         $this->authorize('view', $election);
 
@@ -89,7 +90,7 @@ class ElectionController extends Controller
         $election = Election::create(array_merge(
             clean($request->all()),
             ['bathstudent_id' => $request->get('bathstudent_id') ?? null],
-        ));
+        )); /* @var Election $election */
         File::makeDirectory($election->getManifestoPath(), 0775, true);
         Notify::success('Election created');
 
@@ -105,6 +106,7 @@ class ElectionController extends Controller
      */
     public function edit($id)
     {
+        /* @var Election $election */
         $election = Election::findOrFail($id);
         $this->authorize('update', $election);
 
@@ -124,6 +126,7 @@ class ElectionController extends Controller
      */
     public function update($id, ElectionRequest $request)
     {
+        /* @var Election $election */
         $election  = Election::findOrFail($id);
         $positions = $this->determineElectionPositions($request);
 
@@ -150,7 +153,7 @@ class ElectionController extends Controller
         $this->requireAjax();
 
         // Get the election
-        $election = Election::find($id);
+        $election = Election::find($id); /* @var Election $election */
         if (!$election) {
             return $this->ajaxError('404', 404, 'Couldn\'t find that election.');
         }
@@ -177,13 +180,13 @@ class ElectionController extends Controller
         $this->requireAjax();
 
         // Get the election
-        $election = Election::find($id);
+        $election = Election::find($id); /* @var Election $election */
         if (!$election) {
             return $this->ajaxError('404', 404, 'Couldn\'t find that election.');
         }
 
         // Check that voting has closed
-        if (!$election->hasVotingClosed()) {
+        if (!$election->canModifyResults()) {
             return $this->ajaxError('voting_open', 405, 'Voting has not yet closed.');
         }
 

--- a/app/Http/Controllers/Elections/NominationController.php
+++ b/app/Http/Controllers/Elections/NominationController.php
@@ -28,13 +28,13 @@ class NominationController extends Controller
         $this->authorize('create', Nomination::class);
 
         // Get the election
-        $election = Election::find($electionId);
+        $election = Election::find($electionId); /* @var Election $election */
         if (!$election) {
             return $this->ajaxError('404', 404, 'Couldn\'t find that election.');
         }
 
         // Check that nominations are open
-        if (!$election->isNominationsOpen()) {
+        if (!$election->canModifyNominations()) {
             return $this->ajaxError('nominations_closed', 405, 'Nominations are closed and so cannot be deleted.');
         }
 
@@ -75,8 +75,8 @@ class NominationController extends Controller
     public function manifesto($id, $nominationId)
     {
         // Get the election and nomination
-        $election   = Election::findOrFail($id);
-        $nomination = $election->nominations()->where('id', $nominationId)->first();
+        $election   = Election::findOrFail($id); /* @var Election $election */
+        $nomination = $election->nominations()->where('id', $nominationId)->first(); /* @var Nomination $nomination */
 
         // Authorise
         $this->authorize('manifesto', $nomination);
@@ -109,13 +109,13 @@ class NominationController extends Controller
         $this->requireAjax();
 
         // Get the election
-        $election = Election::find($id);
+        $election = Election::find($id); /* @var Election $election */
         if (!$election) {
             return $this->ajaxError('404', 404, 'Couldn\'t find that election.');
         }
 
         // Check that nominations are open
-        if (!$election->isNominationsOpen()) {
+        if (!$election->canModifyNominations()) {
             return $this->ajaxError('nominations_closed', 405, 'Nominations are closed and so cannot be deleted.');
         }
 

--- a/app/Models/Elections/Election.php
+++ b/app/Models/Elections/Election.php
@@ -223,4 +223,28 @@ class Election extends Model
 
         return $now->gt($this->voting_end);
     }
+
+    /**
+     * Test if the user can make changes to the nominations; either:
+     * - Nominations are open
+     * - The user is an admin
+     *
+     * @return bool
+     */
+    public function canModifyNominations(): bool
+    {
+        return $this->isNominationsOpen() || (auth()->check() && auth()->user()->can('admin'));
+    }
+
+    /**
+     * Test if the user can make changes to the results; either:
+     * - Voting has closed
+     * - The user is an admin
+     *
+     * @return bool
+     */
+    public function canModifyResults(): bool
+    {
+        return $this->hasVotingClosed() || (auth()->check() && auth()->user()->can('admin'));
+    }
 }

--- a/resources/views/elections/view.blade.php
+++ b/resources/views/elections/view.blade.php
@@ -92,7 +92,7 @@
                                             <span class="fa fa-file-pdf-o"></span>
                                             <span>Manifesto</span>
                                         </a>
-                                        @if(Auth::user()->can('delete', $nominee) && $election->isNominationsOpen())
+                                        @if(Auth::user()->can('delete', $nominee) && $election->canModifyNominations())
                                             <a class="btn btn-danger"
                                                data-submit-ajax="{{ route('election.nomination.delete', ['id' => $election->id, 'nominationId' => $nominee->id]) }}"
                                                data-submit-confirm="Are you sure you want to delete this nomination?">
@@ -116,7 +116,7 @@
 
         <p>
             @can('create', \App\Models\Elections\Nomination::class)
-                @if($election->isNominationsOpen())
+                @if($election->canModifyNominations())
                     <button class="btn btn-success"
                             data-toggle="modal"
                             data-target="#modal"
@@ -128,7 +128,7 @@
                 @endif
             @endcan
             @can('update', $election)
-                @if($election->hasVotingClosed())
+                @if($election->canModifyResults())
                     <button class="btn btn-success"
                             data-toggle="modal"
                             data-target="#modal"
@@ -145,12 +145,12 @@
 
 @section('modal')
     @can('create', \App\Models\Elections\Nomination::class)
-        @if($election->isNominationsOpen())
+        @if($election->canModifyNominations())
             @include('elections.modals.nominate')
         @endif
     @endcan
     @can('update', $election)
-        @if($election->hasVotingClosed())
+        @if($election->canModifyResults())
             @include('elections.modals.elect')
         @endif
     @endcan


### PR DESCRIPTION
Allows admins to always add/remove nominations and set the results outside the nomination/voting windows.

Resolves https://github.com/backstage-technical-services/hub/issues/139
