### PR TITLE
feat: update asset register to 2024/25 version

### DIFF
--- a/resources/views/equipment/assets/view.blade.php
+++ b/resources/views/equipment/assets/view.blade.php
@@ -10,5 +10,5 @@
     <iframe width="100%"
             height="700"
             frameborder="0"
-            src="https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRBIJLyKO--ffboCd90BXWBD95DZm99cXXqi9eSnzPkoCMeMIilnRC81udAtD3ghbF4zt5bzeqDLGQb/pubhtml?widget=true&amp;headers=false"></iframe>
+            src="https://docs.google.com/spreadsheets/d/e/2PACX-1vQnhQT5kYi24oPgXIfBIoWEekj8TBwtBzM51kMxzxjVMS0OeBQrq9anGDaq0ifdVFB2cmSpnstQH1mO/pubhtml?widget=true&amp;headers=false"></iframe>
 @endsection


### PR DESCRIPTION
### Issue summary

A new inventory has been taken to account for changes to BTS assets over the past year.
This has been merged into a new copy of the Asset Register Google Spreadsheet for the
2024/25 academic year.

The Asset Register section of the website therefore needs to be updated to point to this
new spreadsheet.

### Work included

- The new Asset Register spreadsheet had been published in an embeddable format using the
  Google Spreadsheets "publish to web" function.
- view.blade.php has been updated with regards to its embedded URL. This URL points
  to the embeddable URL generated by Google Spreadsheets.


### Testing

- I have tested that the new Google Spreadsheets embeddable URL for the 2024/25
  Asset Register is pointing at the right spreadsheet by loading it up manually in a new
  browser window. This has worked as expected.
