### PR TITLE
build: add support for docker compose v2

### DIFF
--- a/scripts/site.sh
+++ b/scripts/site.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 readonly rootDir="$(dirname "$(realpath "${0}")")/.."
-# adds support for compose v2
-if command -v docker-compose >/dev/null 2>&1; then
-  readonly composeCmd="docker-compose"
-else
-  readonly composeCmd="docker compose"
-fi
-
 
 # Ensure that Docker is running...
 if ! docker info >/dev/null 2>&1; then
@@ -62,7 +55,7 @@ EOF
 }
 
 function _docker() {
-  $composeCmd -f "$rootDir/docker-compose.yml" "$@"
+  docker compose -f "$rootDir/docker-compose.yml" "$@"
 }
 
 function _start() {

--- a/scripts/site.sh
+++ b/scripts/site.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -eo pipefail
 readonly rootDir="$(dirname "$(realpath "${0}")")/.."
+# adds support for compose v2
+if command -v docker-compose >/dev/null 2>&1; then
+  readonly composeCmd="docker-compose"
+else
+  readonly composeCmd="docker compose"
+fi
+
 
 # Ensure that Docker is running...
 if ! docker info >/dev/null 2>&1; then
@@ -55,7 +62,7 @@ EOF
 }
 
 function _docker() {
-  docker-compose -f "$rootDir/docker-compose.yml" "$@"
+  $composeCmd -f "$rootDir/docker-compose.yml" "$@"
 }
 
 function _start() {


### PR DESCRIPTION
### Issue summary

The `docker-compose` binary is no longer supported nor standard on new installs. The development tooling references this binary with no easy way of changing it without it appearing in version control. 

### Work included

- Added a check to see if `docker-compose` is installed. If it is, use that in all subsequent commands. Otherwise, use `docker compose`.

### Testing

- Verify that we are not affected by [breaking changes](https://docs.docker.com/compose/releases/migrate/) in Compose V2