### PR TITLE
feat: add PC deployment portal link to members' area

### DIFF
--- a/app/View/Composers/MainMenuComposer.php
+++ b/app/View/Composers/MainMenuComposer.php
@@ -134,6 +134,7 @@ class MainMenuComposer implements ViewComposer
                 $equipMenu->add('View repairs db', route('equipment.repairs.index'));
                 $equipMenu->add('Report broken kit', route('equipment.repairs.create'));
                 $equipMenu->add('PAT database', 'https://assets.bts-crew.com');
+                $equipMenu->add('PC Deployment Portal', 'https://pc-deployment.bts-crew.com');
                 
                 // Training
                 $trainingMenu = $membersMenu->add('Training', '#')

--- a/app/View/Composers/MainMenuComposer.php
+++ b/app/View/Composers/MainMenuComposer.php
@@ -134,7 +134,7 @@ class MainMenuComposer implements ViewComposer
                 $equipMenu->add('View repairs db', route('equipment.repairs.index'));
                 $equipMenu->add('Report broken kit', route('equipment.repairs.create'));
                 $equipMenu->add('PAT database', 'https://assets.bts-crew.com');
-                $equipMenu->add('PC Deployment Portal', 'https://pc-deployment.bts-crew.com');
+                $equipMenu->add('PC deployment portal', config('bts.links.pc_deployment'));
                 
                 // Training
                 $trainingMenu = $membersMenu->add('Training', '#')

--- a/config/bts.php
+++ b/config/bts.php
@@ -16,6 +16,7 @@ return [
         'event_report'    => env('LINK_EVENT_REPORT'),
         'instagram'       => 'https://www.instagram.com/backstageatbath/',
         'wiki'            => 'https://wiki.bts-crew.com',
+        'pc_deployment'   => 'https://pc-deployment.bts-crew.com'
     ],
     
     // Emails


### PR DESCRIPTION
Add menu entry under the "Equipment" section of the "Members' Area" linking to the BTS PC deployment server's web portal.

<!-- PLEASE COMPLETE THIS TO THE BEST OF YOUR ABILITY -->

<!-- NOTE: your PR title will need to conform to the conventional commit spec -->

### Description
Now that BTS has a PC deployment server (with recently configured public-facing subdomain), it would be nice to be able to get to it from the main website, for the sake of publicising it in a standard location.

This pull request adds a "PC Deployment Portal" option to the "Equipment" category of the "Members' Area" drop-down, pointing to this portal.

### Checklist

> [!IMPORTANT]
> Make sure you follow these wherever possible; if you have then check it off, and if not then use a strikethrough (\~)
> to cross it off. This will help the reviewer identify any changes that may have been missed.

**General**

* [X] Documentation updated/written (if applicable)
* [] Good coverage of tests
* [] Updated docker config
* [] CI/CD config updated
* [] Docker image builds and boots

**Principles**

* [X] DRY, SOLID and Clean
* [X] Follows language code style
* [X] Use consistent vocabulary
* [X] Any tech debt justified and ticketed where appropriate
* [X] All data access audited
* [X] Appropriate level of logging
