### PR TITLE
feat: update Members' Area to point to new Skills Matrix

### DIFF
--- a/app/View/Composers/MainMenuComposer.php
+++ b/app/View/Composers/MainMenuComposer.php
@@ -138,18 +138,7 @@ class MainMenuComposer implements ViewComposer
                 $equipMenu->add('Network management portal', config('bts.links.network_management'));
                 
                 // Training
-                $trainingMenu = $membersMenu->add('Training', '#')
-                                            ->attr('class', 'dropdown training');
-                if ($this->isMember) {
-                    $trainingMenu->add('View skills', route('training.skill.index'))
-                                 ->active('training/skills/*');
-                }
-                if ($this->isAdmin) {
-                    $trainingMenu->add('View categories', route('training.category.index'));
-                    $trainingMenu->add('Review applications', route('training.skill.application.index'))
-                                 ->active('training/applications/*');
-                    $trainingMenu->add('Skills log', route('training.skill.log'));
-                }
+                $membersMenu->add('Skills matrix', config('bts.links.skills_matrix'));
                 
                 // Misc
                 $miscMenu = $membersMenu->add('Other', '#')
@@ -160,10 +149,16 @@ class MainMenuComposer implements ViewComposer
                              ->active('elections/*');
                     $miscMenu->add('Awards', route('award.season.index'))
                              ->active('awards/*');
+                    $miscMenu->add('Archive: skills view', route('training.skill.index'))
+                             ->active('training/skills/*');
                 }
                 if ($this->isAdmin) {
                     $miscMenu->add('Backups', route('backup.index'));
                     $miscMenu->add('Webpages', route('page.index'));
+                    $miscMenu->add('Archive: skills categories', route('training.category.index'));
+                    $miscMenu->add('Archive: skills applications', route('training.skill.application.index'))
+                             ->active('training/applications/*');
+                    $miscMenu->add('Archive: skills log', route('training.skill.log'));
                 }
                 
                 // H&S reporting

--- a/app/View/Composers/MainMenuComposer.php
+++ b/app/View/Composers/MainMenuComposer.php
@@ -138,7 +138,21 @@ class MainMenuComposer implements ViewComposer
                 $equipMenu->add('Network management portal', config('bts.links.network_management'));
                 
                 // Training
-                $membersMenu->add('Skills matrix', config('bts.links.skills_matrix'));
+                $trainingMenu = $membersMenu->add('Training', '#')
+                    ->attr('class', 'dropdown training');
+                $trainingMenu->add('Skills matrix', config('bts.links.skills_matrix'));
+
+                $trainingArchiveMenu = $trainingMenu->add('Archive', '#')
+                    ->attr('class', 'dropdown')
+                    ->active('/training/*');
+                $trainingArchiveMenu->add('View skills', route('training.skill.index'))
+                    ->active('/training/skills/*');
+                if ($this->isAdmin) {
+                    $trainingArchiveMenu->add('View categories', route('training.category.index'));
+                    $trainingArchiveMenu->add('Review applications', route('training.skill.application.index'))
+                        ->active('training/applications/*');
+                    $trainingArchiveMenu->add('Skills log', route('training.skill.log'));
+                }
                 
                 // Misc
                 $miscMenu = $membersMenu->add('Other', '#')
@@ -149,16 +163,10 @@ class MainMenuComposer implements ViewComposer
                              ->active('elections/*');
                     $miscMenu->add('Awards', route('award.season.index'))
                              ->active('awards/*');
-                    $miscMenu->add('Archive: skills view', route('training.skill.index'))
-                             ->active('training/skills/*');
                 }
                 if ($this->isAdmin) {
                     $miscMenu->add('Backups', route('backup.index'));
                     $miscMenu->add('Webpages', route('page.index'));
-                    $miscMenu->add('Archive: skills categories', route('training.category.index'));
-                    $miscMenu->add('Archive: skills applications', route('training.skill.application.index'))
-                             ->active('training/applications/*');
-                    $miscMenu->add('Archive: skills log', route('training.skill.log'));
                 }
                 
                 // H&S reporting

--- a/config/bts.php
+++ b/config/bts.php
@@ -17,7 +17,8 @@ return [
         'instagram'       => 'https://www.instagram.com/backstageatbath/',
         'wiki'            => 'https://wiki.bts-crew.com',
         'pc_deployment'   => 'https://pc-deployment.bts-crew.com',
-        'network_management' => 'https://librenms.bts-crew.com'
+        'network_management' => 'https://librenms.bts-crew.com',
+        'skills_matrix'   => 'https://docs.google.com/spreadsheets/d/1Xq3JVDMIE52_0iWZiymMsDvMINEfz0p0G0x2WdImSHo'
     ],
     
     // Emails

--- a/resources/assets/sass/structure/main/menu.scss
+++ b/resources/assets/sass/structure/main/menu.scss
@@ -197,7 +197,7 @@ div#menu-wrapper {
                         &.dropdown {
                             // SECTION: Sub nav bar
                             & > ul {
-                                & > li {
+                                li {
                                     text-align: left;
                                     & > a {
                                         //background: none;
@@ -239,6 +239,13 @@ div#menu-wrapper {
                                                         font-weight: bold;
                                                     }
                                                 }
+                                                @media (max-width: 767px) {
+                                                    &.active {
+                                                        & > a {
+                                                            background: rgba(0, 0, 0, 0.1);
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                         
@@ -262,7 +269,7 @@ div#menu-wrapper {
                                     position: inherit;
                                     width: 100%;
                                     
-                                    & > li {
+                                    li {
                                         & > a {
                                             padding-bottom: 0.75em;
                                             padding-top: 0.75em;
@@ -272,7 +279,7 @@ div#menu-wrapper {
                                             & > ul {
                                                 background: none;
                                                 display: block;
-                                                margin: 0 0.5em;
+                                                margin-left: 0.5em;
                                                 position: inherit;
                                                 width: 100%;
                                             }
@@ -294,7 +301,7 @@ div#menu-wrapper {
                                     //position: absolute;
                                     
                                     // SECTION: Sub nav bar items
-                                    & > li {
+                                    li {
                                         background: $btsyellow;
                                         
                                         &:hover > a, &.active > a {
@@ -335,7 +342,7 @@ div#menu-wrapper {
                                                     & > a {
                                                         display: block;
                                                         font: bold 12px Arial;
-                                                        padding: 0.4em 0 0.4em 1.5em;
+                                                        padding: 0.4em 1.5em;
                                                         
                                                         &:hover {
                                                             text-decoration: underline;
@@ -385,6 +392,10 @@ div#menu-wrapper {
                                         &.admin-users > ul {
                                             width: 11em;
                                         }
+                                    }
+
+                                    & > li.dropdown > ul > li.dropdown > ul {
+                                        background: darken($btsyellow, 15%);
                                     }
                                 }
                             }


### PR DESCRIPTION
<!-- PLEASE COMPLETE THIS TO THE BEST OF YOUR ABILITY -->

<!-- NOTE: your PR title will need to conform to the conventional commit spec -->

### Description

Since 2023, Backstage has moved away from the old website-based skills system and now uses a GSuite-based system, with a master spreadsheet and an automated application form. The old website skills pages, however, have still been live, leading to some confusion from newer members and general difficulty in locating the actual, current, GSuite-based skills matrix.

This PR changes the Members' Area dropdown so that the "Training" entry is now like the "Wiki" entry: it links directly to the new skills matrix sheet. The old training/skills pages have been marked clearly as archived and placed in the "Other" section of the Members' Area drop-down. Committee decided in our last meeting that it would be useful to keep these accessible, but clearly marked as old, for reference purposes, and in case a future committee ever wants to resume using the website system.

### Checklist

> [!IMPORTANT]
> Make sure you follow these wherever possible; if you have then check it off, and if not then use a strikethrough (\~)
> to cross it off. This will help the reviewer identify any changes that may have been missed.

**General**

* [X] Documentation updated/written (if applicable)
* [ ] Good coverage of tests
* [ ] Updated docker config
* [ ] CI/CD config updated
* [ ] Docker image builds and boots

**Principles**

* [X] DRY, SOLID and Clean
* [X] Follows language code style
* [X] Use consistent vocabulary
* [X] Any tech debt justified and ticketed where appropriate
* [X] All data access audited
* [X] Appropriate level of logging
