### PR TITLE
feat: update accident/near-miss e-mails in bts.php

### DIFF
--- a/config/bts.php
+++ b/config/bts.php
@@ -57,14 +57,15 @@ return [
                 'committee@bts-crew.com',
                 'safety@bts-crew.com',
                 'P.Hawker@bath.ac.uk',
-                'cjl25@bath.ac.uk',
+                'su-healthandsafety@bath.ac.uk'
             ],
             'accident_receipt'  => [
                 'safety@bts-crew.com'
             ],
             'near_miss_reports' => [
                 'committee@bts-crew.com',
-                'safety@bts-crew.com'
+                'safety@bts-crew.com',
+                'su-healthandsafety@bath.ac.uk'
             ]
         ],
 


### PR DESCRIPTION
As requested by the SU, the e-mails for accident and near-miss reports have been updated.

### Description

It was requested that our near-miss reports be delivered to the SU, as well as accident reports, in line with the legal reporting obligations. The `su-healthandsafety@bath.ac.uk` e-mail has therefore been added to the list of near-miss recipients.

In terms of accident reports, these are already delivered to the SU, but it was requested that the e-mail there be updated to the new `su-healthandsafety@bath.ac.uk` address, too, so that reports are processed even if Chris Lyon is out of office. It was also pointed out that using this generic address will future-proof against any future staff changes.

### Checklist

> [!IMPORTANT]
> Make sure you follow these wherever possible; if you have then check it off, and if not then use a strikethrough (\~)
> to cross it off. This will help the reviewer identify any changes that may have been missed.

**General**

* [X] Documentation updated/written (if applicable)
* [ ] Good coverage of tests
* [ ] Updated docker config
* [ ] CI/CD config updated
* [ ] Docker image builds and boots

**Principles**

* [X] DRY, SOLID and Clean
* [X] Follows language code style
* [X] Use consistent vocabulary
* [X] Any tech debt justified and ticketed where appropriate
* [X] All data access audited
* [X] Appropriate level of logging
